### PR TITLE
Remove (some) sources of NaN from quadrotor_dynamics

### DIFF
--- a/MIT_MatlabToolbox/trunk/matlab/libs/RoboticsToolbox/quadrotor_dynamics.m
+++ b/MIT_MatlabToolbox/trunk/matlab/libs/RoboticsToolbox/quadrotor_dynamics.m
@@ -180,7 +180,7 @@ function sys = mdlDerivatives(t,x,u, quad)
             sin(j) cos(j)];                               %BBF > mu sideslip rotation matrix
         
         %Flapping
-        beta = [((8/3*quad.theta0 + 2*quad.theta1)*mu - 2*(lc)*mu)/(1-mu^2/2); %Longitudinal flapping
+        beta = [((8/3*quad.theta0 + 2*quad.theta1) - 2*(lc))/(1/mu-mu/2); %Longitudinal flapping
             0;];                                          %sign(w) * (4/3)*((Ct/sigma)*(2*mu*gamma/3/a)/(1+3*e/2/r) + li)/(1+mu^2/2)]; %Lattitudinal flapping (note sign)
         beta = J'*beta;                                   %Rotate the beta flapping angles to longitudinal and lateral coordinates.
         a1s(i) = beta(1) - 16/quad.gamma/abs(w(i)) * o(2);

--- a/MIT_MatlabToolbox/trunk/matlab/libs/RoboticsToolbox/quadrotor_dynamics.m
+++ b/MIT_MatlabToolbox/trunk/matlab/libs/RoboticsToolbox/quadrotor_dynamics.m
@@ -199,7 +199,11 @@ function sys = mdlDerivatives(t,x,u, quad)
     
     dv = (quad.g*e3 + R*(1/quad.M)*sum(T,2));
     do = inv(quad.J)*(-cross(o,quad.J*o) + sum(tau,2) + sum(Q,2)); %row sum of torques
-    sys = [dz;dn;dv;do];                                           %This is the state derivative vector
+    if isnan(do)
+      warning('system rotating too fast!')
+      do = zeros(size(do));
+    end
+    sys = [dz;dn;dv;do];                                         %This is the state derivative vector
 end % End of mdlDerivatives.
 
 


### PR DESCRIPTION
This (helps) prevent NaN's from being produced in the quadrotor dynamics, and causing cryptic and contradictory error messages. This fixes:
- `NaN`s produced by evaluating `inf / (1 - inf^2)`, which can be fixed by reordering operands
- `NaN`s produced by evaluating `sin(inf)`. These are masked out as zeros, and a warning printed, because if the orientation is infinite, we have bigger problems anyway. No error is thrown, since the unstable behaviour should be obvious from state plots.
