### PR TITLE
Make simulink code generation work on r2015b

### DIFF
--- a/MIT_MatlabToolbox/trunk/embcode/rtw_matlogging.h
+++ b/MIT_MatlabToolbox/trunk/embcode/rtw_matlogging.h
@@ -122,7 +122,7 @@ typedef struct _RTWLogInfo_tag {
   const void * mmi;    /* Add the ModelMapping Info to the LogInfo 
                         * so we can get at it for state logging */
 
-
+  void* loggingInterval;
 } RTWLogInfo;
 
 #endif


### PR DESCRIPTION
This fixing the compilation error due to a missing struct member. Since the member isn't actually used, we can just declare it as a void pointer.

This shouldn't affect the 2015a behaviour, since we don't need binary compatibility - the source is recompiled each time.
