### PR TITLE
Set default IP

### DIFF
--- a/MIT_MatlabToolbox/trunk/embcode/rsedu_control.c
+++ b/MIT_MatlabToolbox/trunk/embcode/rsedu_control.c
@@ -833,6 +833,7 @@ void RSEDU_control(HAL_acquisition_t* hal_sensors_data, HAL_command_t* hal_senso
 
     //communication
     static char serverIP[16];
+    strncpy(serverIP, "192.168.1.2", 16);
     static int sockfd = 0;
     static char recvBuff[100];
     static struct sockaddr_in serv_addr;


### PR DESCRIPTION
Since the drone output says "File missing, using defaults", it should probably use a real IP address and not the empty string (since all statics are default-initialized to zeros).
